### PR TITLE
Refactor about page

### DIFF
--- a/src/utils/get-year-month.ts
+++ b/src/utils/get-year-month.ts
@@ -1,4 +1,0 @@
-export const getYearMonth = (date: string) => {
-  const ISOString = new Date(date)
-  return `${ISOString.getFullYear()}.${ISOString.getMonth() + 1}`
-}


### PR DESCRIPTION
個人的にはもとのままでも十分だと思いました！

- クラスを使ったらこう書けるという提案がメインです
- `getYearMonth` 関数は汎用的というよりは  about ページのデザインに依存していそうだったので、utils から移動してみました（ほかでも使う予定があれば utils でもよさそうです）